### PR TITLE
Add emigration and immigration for subunits as separate components

### DIFF
--- a/R/calculate_projection.R
+++ b/R/calculate_projection.R
@@ -9,7 +9,7 @@
 #'
 calculate_projection <- function(.data, subregional = FALSE) {
   # Cohort component method
-  .data |>
+  out <- .data |>
     mutate(
       .by = spatial_unit,
       # placeholder for newborns (those will be calculated later)
@@ -18,6 +18,8 @@ calculate_projection <- function(.data, subregional = FALSE) {
       emi_int_n = n_jan * (emi_int * (1 - (mor / 2))),
       # emigration to other cantons
       emi_nat_n = n_jan * (emi_nat * (1 - (mor / 2))),
+      # emigration to other subregional units
+      emi_sub_n = n_jan * (emi_sub * (1 - (mor / 2))),
       # acquisition of the Swiss citizenship
       acq_n = n_jan * (acq * (1 - (mor / 2))),
       # subtract new Swiss citizens from the international population
@@ -25,11 +27,23 @@ calculate_projection <- function(.data, subregional = FALSE) {
       # mortality (deaths)
       mor_n = n_jan - (n_jan * (1 - mor)),
       # calculate the population balance
-      n_dec = case_when(
-        subregional == TRUE ~ n_jan - mor_n - emi_int_n - emi_nat_n + acq_n +
-          imm_int_n + imm_nat_n + mig_sub,
-        .default = n_jan - mor_n - emi_int_n - emi_nat_n + acq_n +
-          imm_int_n + imm_nat_n
-      )
+      n_dec = n_jan - mor_n - emi_int_n - emi_nat_n - emi_sub_n +
+          acq_n + imm_int_n + imm_nat_n
     )
+
+  # Redistribute subregional emigration back to all subregional units as immigration
+  if(subregional){
+    # Get total of subregional emigration
+    dat_emi_sub_n_total <- out |>
+      dplyr::summarise(.by = c(year, nat, sex, age), emi_sub_n_total = sum(emi_sub_n))
+
+    # Redistribution according to provided shares for each subregion
+    out |>
+      dplyr::left_join(dat_emi_sub_n_total,
+                       by = dplyr::join_by(year, nat, sex, age)) |>
+      dplyr::mutate(imm_sub_n = imm_sub * emi_sub_n_total,
+                    n_dec = n_dec + imm_sub_n)
+  } else{
+    return(out)
+  }
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -30,6 +30,7 @@ utils::globalVariables(c(
   "nat", # <calculate_newborns>
   "emi_int", # <calculate_newborns>
   "emi_nat", # <calculate_newborns>
+  "emi_sub", # <calculate_newborns>
   "acq", # <calculate_newborns>
   "acq_n", # <calculate_newborns>
   "mor", # <calculate_newborns>
@@ -38,19 +39,32 @@ utils::globalVariables(c(
   "mor_n", # <calculate_newborns>
   "emi_int_n", # <calculate_newborns>
   "emi_nat_n", # <calculate_newborns>
+  "emi_sub_n", # <calculate_newborns>
+  "imm_sub", # <calculate_newborns>
+  "emi_sub_n_total", # <calculate_newborns>
+  "imm_sub_n", # <calculate_newborns>
   "spatial_unit", # <calculate_projection>
   "n_jan", # <calculate_projection>
   "emi_int", # <calculate_projection>
   "mor", # <calculate_projection>
   "emi_nat", # <calculate_projection>
+  "emi_sub", # <calculate_projection>
   "acq", # <calculate_projection>
   "nat", # <calculate_projection>
   "acq_n", # <calculate_projection>
   "mor_n", # <calculate_projection>
   "emi_int_n", # <calculate_projection>
   "emi_nat_n", # <calculate_projection>
+  "emi_sub_n", # <calculate_projection>
   "imm_int_n", # <calculate_projection>
   "imm_nat_n", # <calculate_projection>
+  "year", # <calculate_projection>
+  "sex", # <calculate_projection>
+  "age", # <calculate_projection>
+  "imm_sub", # <calculate_projection>
+  "emi_sub_n_total", # <calculate_projection>
+  "n_dec", # <calculate_projection>
+  "imm_sub_n", # <calculate_projection>
   "age", # <calculate_shares>
   "sum_5", # <calculate_shares>
   "sum_10", # <calculate_shares>
@@ -134,26 +148,9 @@ utils::globalVariables(c(
   "nat", # <prepare_evaluation>
   "year", # <project_population>
   "age", # <project_population>
-  "nat", # <project_population>
   "sex", # <project_population>
-  "scen", # <project_population>
+  "nat", # <project_population>
   "spatial_unit", # <project_population>
-  "birthrate", # <project_population>
-  "int_mothers", # <project_population>
-  "mor", # <project_population>
-  "emi_int", # <project_population>
-  "emi_nat", # <project_population>
-  "imm_int_n", # <project_population>
-  "imm_nat_n", # <project_population>
-  "acq", # <project_population>
-  "mig_sub", # <project_population>
-  "n_jan", # <project_population>
-  "births", # <project_population>
-  "emi_int_n", # <project_population>
-  "emi_nat_n", # <project_population>
-  "acq_n", # <project_population>
-  "mor_n", # <project_population>
-  "n_dec", # <project_population>
   "year", # <project_raw>
   "age", # <project_raw>
   "parameter", # <project_raw>

--- a/R/project_population.R
+++ b/R/project_population.R
@@ -131,7 +131,7 @@ project_population <- function(
       by = c("year", "spatial_unit", "nat", "sex", "age")
     ) |>
     # use helper function to calculate projections
-    calculate_projection() |>
+    calculate_projection(subregional = subregional) |>
     # bind results of year t and year t+1
     bind_rows(population)
 
@@ -143,25 +143,19 @@ project_population <- function(
       parameters = parameters,
       fert_first = fert_first,
       fert_last = fert_last,
-      share_born_female = share_born_female
+      share_born_female = share_born_female,
+      subregional = subregional
     )
 
   # Projection result ----
   # Bind results of year t and year t+1
   population_out <- population_new |>
-    full_join(
-      newborns,
-      by = join_by(
-        nat, sex, age, year, scen, spatial_unit, birthrate, int_mothers, mor,
-        emi_int, emi_nat, imm_int_n,  imm_nat_n, acq, mig_sub, n_jan, births,
-        emi_int_n, emi_nat_n, acq_n, mor_n, n_dec
-      )
-    ) |>
+    bind_rows(newborns) |>
     # clean the data
     select(any_of(c(
       "year", "spatial_unit", "nat", "sex", "age", "births", "n_jan",
-      "mor_n", "emi_int_n", "emi_nat_n", "imm_int_n", "imm_nat_n", "acq_n",
-      "mig_sub", "n_dec"
+      "mor_n", "emi_int_n", "emi_nat_n", "emi_sub_n", "imm_int_n", "imm_nat_n",
+      "imm_sub_n", "acq_n", "n_dec"
     ))) |>
     mutate(
       sex = factor(sex, levels = c("m", "f")),


### PR DESCRIPTION
Emigration from spatial sub-units is handled like other emigration factors in the model (rate of people emigrating to other spatial sub-units is used: must be provided by user). Persons that emigrated from a spatial sub-unit are redistributed to other spatial sub-units as immigrants. Therefore, immigration numbers must not be provided but shares to distribute.

See comments in commit for other code edits.